### PR TITLE
Correct array syntax for PHP 7.4 Compatibility

### DIFF
--- a/src/OAuth/OAuthSignatureMethod.php
+++ b/src/OAuth/OAuthSignatureMethod.php
@@ -59,7 +59,7 @@ abstract class OAuthSignatureMethod
         // Avoid a timing leak with a (hopefully) time insensitive compare
         $result = 0;
         for ($i = 0; $i < strlen($signature); $i++) {
-            $result |= ord($built{$i}) ^ ord($signature{$i});
+            $result |= ord($built[$i]) ^ ord($signature[$i]);
         }
 
         return $result == 0;


### PR DESCRIPTION
Array and string offset access syntax with curly braces is deprecated.
Changed to prevent warning message with PHP 7.4.