### PR TITLE
Fix Unknown column in lti2_user_result when using MYSQL .sql to create tables

### DIFF
--- a/sql/lti3-tables-mysql.sql
+++ b/sql/lti3-tables-mysql.sql
@@ -105,7 +105,7 @@ ALTER TABLE lti2_user
 
 CREATE TABLE lti2_user_result (
   user_result_pk int(11) AUTO_INCREMENT,
-  user_pk int(11) NOT NULL,
+  lti_user_id int(11) NOT NULL,
   resource_link_pk int(11) NOT NULL,
   lti_result_sourcedid varchar(1024) NOT NULL,
   created datetime NOT NULL,
@@ -114,7 +114,7 @@ CREATE TABLE lti2_user_result (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 ALTER TABLE lti2_user_result
-  ADD CONSTRAINT lti2_user_result_lti2_user_FK1 FOREIGN KEY (user_pk)
+  ADD CONSTRAINT lti2_user_result_lti2_user_FK1 FOREIGN KEY (lti_user_id)
   REFERENCES lti2_user (user_pk);
 
 ALTER TABLE lti2_user_result


### PR DESCRIPTION
Update the MySQL creation .sql file to use column name `lti_user_id` as found in PHP rather than `user_pk`.

Fixes multiple select and insert statements for the `lti2_user_result` table such as:

```
[ERROR] SELECT user_result_pk, resource_link_pk, lti_user_id, lti_result_sourcedid, created, updated FROM lti2_user_result WHERE (resource_link_pk = 4) AND (lti_user_id = '2')

array (
  0 => 
  array (
    'errno' => 1054,
    'sqlstate' => '42S22',
    'error' => 'Unknown column \'lti_user_id\' in \'field list\'',
  ),
)
```

```
INSERT INTO lti2_user_result (resource_link_pk, lti_user_id, lti_result_sourcedid, created, updated) VALUES (4, '2', '{\"data\":{\"instanceid\":\"3\",\"userid\":\"2\",\"typeid\":\"2\",\"launchid\":1009604059},\"hash\":\"9f4aef361132a9b0505506bed107dfd6d119a2a4ce76f369034e2ac1f8e7272c\"}', '2020-05-31 23:17:26', '2020-05-31 23:17:26')

array (
  0 => 
  array (
    'errno' => 1054,
    'sqlstate' => '42S22',
    'error' => 'Unknown column \'lti_user_id\' in \'field list\'',
  ),
)
```