### PR TITLE
Outcome Result Data extension support

### DIFF
--- a/src/Outcome.php
+++ b/src/Outcome.php
@@ -91,6 +91,20 @@ class Outcome
     public $dataSource = null;
 
     /**
+     * Outcome result data type.
+     *
+     * @var string|null $resultDataType
+     */
+    public $resultDataType = null;
+
+    /**
+     * Outcome result data.
+     *
+     * @var string|null $resultData
+     */
+    public $resultData = null;
+
+    /**
      * Outcome value.
      *
      * @var string|null $value

--- a/src/ResourceLink.php
+++ b/src/ResourceLink.php
@@ -721,13 +721,22 @@ class ResourceLink
             if (!empty($do)) {
                 $xml = '';
                 if ($action === self::EXT_WRITE) {
+                    $resultDataExt = $sourceResourceLink->getSetting('ext_outcome_data_values_accepted');
+                    if (!empty($resultDataExt) && in_array($ltiOutcome->resultDataType, explode(',',$resultDataExt)) && !empty($ltiOutcome->resultData)) {
+                        $xml = <<< EOF
+
+          <resultData>
+            <{$ltiOutcome->resultDataType}>{$ltiOutcome->resultData}</{$ltiOutcome->resultDataType}>
+          </resultData>
+EOF;
+                    }
                     $xml = <<< EOF
 
         <result>
           <resultScore>
             <language>{$ltiOutcome->language}</language>
             <textString>{$ltiOutcome->getValue()}</textString>
-          </resultScore>
+          </resultScore>{$xml}
         </result>
 EOF;
                 }
@@ -780,8 +789,8 @@ EOF;
                 if (!empty($ltiOutcome->type)) {
                     $params['result_resultvaluesourcedid'] = $ltiOutcome->type;
                 }
-                if (!empty($ltiOutcome->data_source)) {
-                    $params['result_datasource'] = $ltiOutcome->data_source;
+                if (!empty($ltiOutcome->dataSource)) {
+                    $params['result_datasource'] = $ltiOutcome->dataSource;
                 }
                 if ($this->doService($do, $urlExt, $params, 'https://purl.imsglobal.org/spec/lti-ext/scope/outcomes')) {
                     switch ($action) {

--- a/src/Tool.php
+++ b/src/Tool.php
@@ -69,7 +69,7 @@ class Tool
      * Names of LTI parameters to be retained in the resource link settings property.
      */
     private static $LTI_RESOURCE_LINK_SETTING_NAMES = array('lis_result_sourcedid', 'lis_outcome_service_url',
-        'ext_ims_lis_basic_outcome_url', 'ext_ims_lis_resultvalue_sourcedids',
+        'ext_ims_lis_basic_outcome_url', 'ext_outcome_data_values_accepted', 'ext_ims_lis_resultvalue_sourcedids',
         'ext_ims_lis_memberships_id', 'ext_ims_lis_memberships_url',
         'ext_ims_lti_tool_setting', 'ext_ims_lti_tool_setting_id', 'ext_ims_lti_tool_setting_url',
         'custom_link_setting_url', 'custom_link_memberships_url',


### PR DESCRIPTION
Some LMS platforms (e.g Canvas) support the [Result Data extension](https://www.edu-apps.org/extensions/result_data.html). Using this extension, an integration can optionally add URL, text or other supported types of data to Outcome. One use case is to deep link a page (e.g a result page in my scenario).

While working on the code, I noticed and fixed typo, too. Outcome's data source is referenced as data_source, while it is written as dataSource in the class' source code.