### PR TITLE
[3.x] Ignore version when parsing consumerVersion

### DIFF
--- a/src/ToolConsumer.php
+++ b/src/ToolConsumer.php
@@ -318,7 +318,7 @@ class ToolConsumer
     {
         $familyCode = '';
         if (!empty($this->consumerVersion)) {
-            list($familyCode, $version) = explode('-', $this->consumerVersion, 2);
+            list($familyCode) = explode('-', $this->consumerVersion, 2);
         }
 
         return $familyCode;


### PR DESCRIPTION
The tool_consumer_info_version parameter is recommended, but not required so it might not be present. The code in the getFamilyCode function assumes it is always present when consumerVersion isn't empty. Since we don't use the version here, we can simply ignore it.