### PR TITLE
fix: consider message_supported values as strings

### DIFF
--- a/src/Tool.php
+++ b/src/Tool.php
@@ -840,7 +840,7 @@ class Tool
         $claimsSupported = $platformConfig['claims_supported'];
         $messagesSupported = [];
         foreach ($platformConfig['https://purl.imsglobal.org/spec/lti-platform-configuration']['messages_supported'] as $message) {
-            $messagesSupported[] = $message['type'];
+            $messagesSupported[] = is_string($message) ? $message : $message['type'] ?? '';
         }
         $scopesSupported = $platformConfig['scopes_supported'];
         $iconUrl = null;


### PR DESCRIPTION
This PR allows to manage `message_supported` values from open-id-configuration endpoints during dynamic registration.

Moodle (at least v3.11.14), sends `message_supported` values as an array of strings, for example:

```json
{
    "issuer": "...",
    "token_endpoint": "...",
    "token_endpoint_auth_methods_supported": [
        "private_key_jwt"
    ],
    "token_endpoint_auth_signing_alg_values_supported": [
        "RS256"
    ],
    "jwks_uri": "...",
    "authorization_endpoint": "...",
    "registration_endpoint": "...",
    "scopes_supported": [
        "https://purl.imsglobal.org/spec/lti-bo/scope/basicoutcome",
        "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly",
        "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
        "https://purl.imsglobal.org/spec/lti-ags/scope/score",
        "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
        "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly",
        "https://purl.imsglobal.org/spec/lti-ts/scope/toolsetting",
        "openid"
    ],
    "response_types_supported": [
        "id_token"
    ],
    "subject_types_supported": [
        "public",
        "pairwise"
    ],
    "id_token_signing_alg_values_supported": [
        "RS256"
    ],
    "claims_supported": [
        "sub",
        "iss",
        "name",
        "given_name",
        "family_name",
        "email"
    ],
    "https://purl.imsglobal.org/spec/lti-platform-configuration": {
        "product_family_code": "moodle",
        "version": "3.11.4 (Build: 20211108)",
        "messages_supported": [
            "LtiResourceLinkRequest",
            "LtiDeepLinkingRequest",
             ...
        ],
        "placements": [
            "AddContentMenu"
        ],
        "variables": [
            "basic-lti-launch-request",
            "ContentItemSelectionRequest",
           ...
        ]
    }
}
```

It would fix the following error:
```bash
"PHP message: PHP Fatal error:  Uncaught TypeError: Cannot access offset of type string on string in celtic-lti/vendor/celtic/lti/src/Tool.php:843
```


### Testing case
- Use Moodle 3.11.14 as a platform
- Use Pressbooks as a tool
- Register the tool dynamically
- You should not see the error displayed above
- The tool should be registered as expected, with Deep Linking and other specified messages enabled.