### PR TITLE
Allow empty deployment_id on response, is an optional parameter

### DIFF
--- a/src/Tool.php
+++ b/src/Tool.php
@@ -986,7 +986,7 @@ class Tool
         $this->platform->signatureMethod = reset($platformConfig['id_token_signing_alg_values_supported']);
         $this->platform->platformId = $platformConfig['issuer'];
         $this->platform->clientId = $registrationConfig['client_id'];
-        $this->platform->deploymentId = $registrationConfig['https://purl.imsglobal.org/spec/lti-tool-configuration']['deployment_id'];
+        $this->platform->deploymentId = $registrationConfig['https://purl.imsglobal.org/spec/lti-tool-configuration']['deployment_id'] ?? '';
         $this->platform->authenticationUrl = $platformConfig['authorization_endpoint'];
         $this->platform->accessTokenUrl = $platformConfig['token_endpoint'];
         $this->platform->jku = $platformConfig['jwks_uri'];


### PR DESCRIPTION
Hi! dynamic registration defines as optional parameter "deployment_id"

https://www.imsglobal.org/spec/lti-dr/v1p0#lti-configuration-0

I suggest to make it optional 

Thanks!

