### PR TITLE
fix: replace array_merge_recursive with array_merge to overwrite defaults

### DIFF
--- a/src/OAuth/OAuthRequest.php
+++ b/src/OAuth/OAuthRequest.php
@@ -170,7 +170,7 @@ class OAuthRequest
             $defaults['oauth_token'] = $token->key;
         }
 
-        $parameters = OAuthUtil::array_merge_recursive($defaults, $parameters);
+        $parameters = array_merge($defaults, $parameters);
 
         return new OAuthRequest($http_method, $http_url, $parameters);
     }


### PR DESCRIPTION
The parameters need to overwrite the defaults in this instance. now you get an array with an array as value instead of array<array-key, string|int>