### PR TITLE
add more Media Types as class constants

### DIFF
--- a/src/Service/AssessmentControl.php
+++ b/src/Service/AssessmentControl.php
@@ -18,6 +18,11 @@ class AssessmentControl extends Service
 {
 
     /**
+     * Media type for the Assessment Control service.
+     */
+    public const MEDIA_TYPE_ASSESSMENT_CONTROL = 'application/vnd.ims.lti-ap.v1.control+json';
+
+    /**
      * Access scope.
      *
      * @var string $SCOPE
@@ -42,7 +47,7 @@ class AssessmentControl extends Service
         parent::__construct($resourceLink->getPlatform(), $endpoint);
         $this->resourceLink = $resourceLink;
         $this->scope = self::$SCOPE;
-        $this->mediaType = 'application/vnd.ims.lti-ap.v1.control+json';
+        $this->mediaType = self::MEDIA_TYPE_ASSESSMENT_CONTROL;
     }
 
     /**

--- a/src/Service/Result.php
+++ b/src/Service/Result.php
@@ -19,6 +19,11 @@ class Result extends AssignmentGrade
 {
 
     /**
+     * Media type for the Result service.
+     */
+    public const MEDIA_TYPE_RESULTS = 'application/vnd.ims.lis.v2.resultcontainer+json';
+
+    /**
      * Access scope.
      *
      * @var string $SCOPE
@@ -64,7 +69,7 @@ class Result extends AssignmentGrade
         $this->limit = $limit;
         $this->pagingMode = $pagingMode;
         $this->scope = self::$SCOPE;
-        $this->mediaType = 'application/vnd.ims.lis.v2.resultcontainer+json';
+        $this->mediaType = self::MEDIA_TYPE_RESULTS;
     }
 
     /**

--- a/src/Service/Result.php
+++ b/src/Service/Result.php
@@ -21,7 +21,7 @@ class Result extends AssignmentGrade
     /**
      * Media type for the Result service.
      */
-    public const MEDIA_TYPE_RESULTS = 'application/vnd.ims.lis.v2.resultcontainer+json';
+    public const MEDIA_TYPE_RESULT = 'application/vnd.ims.lis.v2.resultcontainer+json';
 
     /**
      * Access scope.
@@ -69,7 +69,7 @@ class Result extends AssignmentGrade
         $this->limit = $limit;
         $this->pagingMode = $pagingMode;
         $this->scope = self::$SCOPE;
-        $this->mediaType = self::MEDIA_TYPE_RESULTS;
+        $this->mediaType = self::MEDIA_TYPE_RESULT;
     }
 
     /**

--- a/src/Service/Score.php
+++ b/src/Service/Score.php
@@ -16,6 +16,10 @@ use ceLTIc\LTI\Outcome;
  */
 class Score extends AssignmentGrade
 {
+    /**
+     * Media type for the Score service.
+     */
+    public const MEDIA_TYPE_SCORE = 'application/vnd.ims.lis.v1.score+json';
 
     /**
      * Access scope.
@@ -34,7 +38,7 @@ class Score extends AssignmentGrade
     {
         parent::__construct($platform, $endpoint, '/scores');
         $this->scope = self::$SCOPE;
-        $this->mediaType = 'application/vnd.ims.lis.v1.score+json';
+        $this->mediaType = self::MEDIA_TYPE_SCORE;
     }
 
     /**

--- a/src/Service/ToolSettings.php
+++ b/src/Service/ToolSettings.php
@@ -20,6 +20,16 @@ class ToolSettings extends Service
 {
 
     /**
+     * Media type for tool settings service.
+     */
+    public const MEDIA_TYPE_TOOL_SETTINGS = 'application/vnd.ims.lti.v2.toolsettings+json';
+
+    /**
+     * Media type for tool settings simple service.
+     */
+    public const MEDIA_TYPE_TOOL_SETTINGS_SIMPLE = 'application/vnd.ims.lti.v2.toolsettings.simple+json';
+
+    /**
      * Access scope.
      *
      * @var string $SCOPE
@@ -68,9 +78,9 @@ class ToolSettings extends Service
         parent::__construct($platform, $endpoint);
         $this->scope = self::$SCOPE;
         if ($simple) {
-            $this->mediaType = 'application/vnd.ims.lti.v2.toolsettings.simple+json';
+            $this->mediaType = self::MEDIA_TYPE_TOOL_SETTINGS_SIMPLE;
         } else {
-            $this->mediaType = 'application/vnd.ims.lti.v2.toolsettings+json';
+            $this->mediaType = self::MEDIA_TYPE_TOOL_SETTINGS;
         }
         $this->source = $source;
         $this->simple = $simple;


### PR DESCRIPTION
This PR adds consistency in handling media types.

Two additional notes for future consideration:

- Rename LTI_LINK_MEDIA_TYPE and LTI_ASSIGNMENT_MEDIA_TYPE to follow the new format. Deprecate these constants if they're used in existing implementations. If needed I can add this change to this PR.

- Consider creating Enum classes for Media Types, Scopes, etc., to simplify string validation in the code.