### PR TITLE
Fix PHP 8.4 deprecation: Implicitly marking parameter as nullable

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -658,7 +658,7 @@ class Context
      *
      * @return bool  True if context was successfully loaded
      */
-    private function load(int $id = null): bool
+    private function load(?int $id = null): bool
     {
         $this->initialize();
         $this->id = $id;

--- a/src/DataConnector/DataConnector.php
+++ b/src/DataConnector/DataConnector.php
@@ -123,7 +123,7 @@ class DataConnector
      *
      * @return bool  True if memcache is enabled
      */
-    public static function useMemcache(string $host = null, int $port = -1): bool
+    public static function useMemcache(?string $host = null, int $port = -1): bool
     {
         if (is_null($host)) {
             $useMemcache = !empty(self::$memcache);

--- a/src/Platform.php
+++ b/src/Platform.php
@@ -514,7 +514,7 @@ class Platform
      * @return Platform  The platform object
      */
     public static function fromPlatformId(string $platformId, ?string $clientId, ?string $deploymentId,
-        DataConnector $dataConnector = null, bool $autoEnable = false): Platform
+        ?DataConnector $dataConnector = null, bool $autoEnable = false): Platform
     {
         $platform = new static($dataConnector);
         $platform->platformId = $platformId;

--- a/src/Profile/Item.php
+++ b/src/Profile/Item.php
@@ -65,7 +65,7 @@ class Item
      * @param string|null $version      Version of item (optional)
      * @param int|null $timestamp       Timestamp of item (optional)
      */
-    function __construct(string $id = null, ?string $name = null, ?string $description = null, ?string $url = null,
+    function __construct(?string $id = null, ?string $name = null, ?string $description = null, ?string $url = null,
         ?string $version = null, ?int $timestamp = null)
     {
         $this->id = $id;

--- a/src/Tool.php
+++ b/src/Tool.php
@@ -451,7 +451,7 @@ class Tool
      * @param bool $disableCookieCheck  True if no cookie check should be made (optional, default is false)
      * @param bool $generateWarnings    True if warning messages should be generated (optional, default is false)
      */
-    public function handleRequest(bool $strictMode = null, bool $disableCookieCheck = false, bool $generateWarnings = false): void
+    public function handleRequest(?bool $strictMode = null, bool $disableCookieCheck = false, bool $generateWarnings = false): void
     {
         $currentStrictMode = Util::$strictMode;
         if (!is_null($strictMode)) {
@@ -1154,7 +1154,7 @@ EOD;
      *
      * @return Tool  The tool object
      */
-    public static function fromConsumerKey(?string $key = null, DataConnector $dataConnector = null, bool $autoEnable = false): Tool
+    public static function fromConsumerKey(?string $key = null, ?DataConnector $dataConnector = null, bool $autoEnable = false): Tool
     {
         $tool = new static($dataConnector);
         $tool->key = $key;
@@ -1177,7 +1177,7 @@ EOD;
      *
      * @return Tool  The tool object
      */
-    public static function fromInitiateLoginUrl(string $initiateLoginUrl, DataConnector $dataConnector = null,
+    public static function fromInitiateLoginUrl(string $initiateLoginUrl, ?DataConnector $dataConnector = null,
         bool $autoEnable = false): Tool
     {
         $tool = new static($dataConnector);


### PR DESCRIPTION
Errors were detected via PHPStan, and fixed using Rector via this `rector.php` config:
```php
<?php

declare(strict_types=1);


return Rector\Config\RectorConfig::configure()
    ->withPaths([__DIR__ . '/src'])
    ->withPhpVersion(Rector\ValueObject\PhpVersion::PHP_84)
    ->withRules([
        Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector::class,
    ]);

```
