### PR TITLE
Fix PHPSessionClient not reopening session after setId()

### DIFF
--- a/src/Session/PHPSessionClient.php
+++ b/src/Session/PHPSessionClient.php
@@ -33,6 +33,7 @@ class PHPSessionClient implements ClientInterface
     public function setId(string $id): void
     {
         session_id($id);
+        session_start();
     }
 
     /**


### PR DESCRIPTION
When parseMessage() switches sessions via closeSession() / setId() / openSession(), PHPSessionClient::setId() set the new ID but never started the session. openSession() then skipped session_start(), leaving authentication data unreadable and causing LTI 1.3 launches to fail when state carried a .<sessionId> suffix.